### PR TITLE
Better error handling & tests

### DIFF
--- a/cjs/EventEmitterAsyncIterator.d.ts
+++ b/cjs/EventEmitterAsyncIterator.d.ts
@@ -4,8 +4,9 @@ declare type ResolveResult = (arg: {
     value: any;
     done: boolean;
 }) => void;
+declare type RejectResult = (error: Error) => void;
 declare class EventEmitterAsyncIterator extends EventEmitter implements AsyncIterator<any> {
-    protected pullQueue: ResolveResult[];
+    protected pullQueue: Array<[ResolveResult, RejectResult]>;
     protected pushQueue: any[];
     protected listening: boolean;
     readonly [iterall.$$asyncIterator]: () => this;

--- a/cjs/EventEmitterAsyncIterator.d.ts
+++ b/cjs/EventEmitterAsyncIterator.d.ts
@@ -1,8 +1,12 @@
 import EventEmitter from "eventemitter3";
 import iterall from "iterall";
+declare type ResolveResult = (arg: {
+    value: any;
+    done: boolean;
+}) => void;
 declare class EventEmitterAsyncIterator extends EventEmitter implements AsyncIterator<any> {
-    protected pullQueue: any[];
-    protected pushQueue: Promise<any>[];
+    protected pullQueue: ResolveResult[];
+    protected pushQueue: any[];
     protected listening: boolean;
     readonly [iterall.$$asyncIterator]: () => this;
     constructor();

--- a/cjs/EventEmitterAsyncIterator.d.ts
+++ b/cjs/EventEmitterAsyncIterator.d.ts
@@ -10,6 +10,7 @@ declare class EventEmitterAsyncIterator extends EventEmitter implements AsyncIte
     protected pushQueue: any[];
     protected listening: boolean;
     readonly [iterall.$$asyncIterator]: () => this;
+    readonly [Symbol.asyncIterator]: () => this;
     constructor();
     emptyQueue(): void;
     pullValue(): Promise<IteratorResult<any, any>>;

--- a/cjs/EventEmitterAsyncIterator.js
+++ b/cjs/EventEmitterAsyncIterator.js
@@ -16,7 +16,7 @@ class EventEmitterAsyncIterator extends eventemitter3_1.default {
     emptyQueue() {
         if (this.listening) {
             this.listening = false;
-            this.pullQueue.forEach((resolve) => {
+            this.pullQueue.forEach(([resolve]) => {
                 return resolve({ value: undefined, done: true });
             });
             this.pullQueue.length = 0;
@@ -25,22 +25,24 @@ class EventEmitterAsyncIterator extends eventemitter3_1.default {
     }
     pullValue() {
         const self = this;
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
             if (self.pushQueue.length !== 0)
                 resolve({
                     value: self.pushQueue.shift(),
                     done: false
                 });
             else
-                self.pullQueue.push(resolve);
+                self.pullQueue.push([resolve, reject]);
         });
     }
     pushValue(event) {
-        if (this.pullQueue.length !== 0)
-            this.pullQueue.shift()({
+        if (this.pullQueue.length !== 0) {
+            const [resolve] = this.pullQueue.shift();
+            resolve({
                 value: event,
                 done: false
             });
+        }
         else
             this.pushQueue.push(event);
     }
@@ -48,6 +50,11 @@ class EventEmitterAsyncIterator extends eventemitter3_1.default {
         return (this.listening ? this.pullValue() : this.return());
     }
     throw(error) {
+        this.listening = false;
+        if (this.pullQueue.length !== 0) {
+            const [resolve, reject] = this.pullQueue.shift();
+            reject(error);
+        }
         this.emptyQueue();
         return Promise.reject(error);
     }

--- a/cjs/EventEmitterAsyncIterator.js
+++ b/cjs/EventEmitterAsyncIterator.js
@@ -12,6 +12,9 @@ class EventEmitterAsyncIterator extends eventemitter3_1.default {
         this.pushQueue = [];
         this.listening = true;
         this[iterall_1.default.$$asyncIterator] = () => this;
+        if (Symbol.asyncIterator) {
+            this[Symbol.asyncIterator] = () => this;
+        }
     }
     emptyQueue() {
         if (this.listening) {
@@ -51,10 +54,10 @@ class EventEmitterAsyncIterator extends eventemitter3_1.default {
     }
     throw(error) {
         this.listening = false;
-        if (this.pullQueue.length !== 0) {
-            const [resolve, reject] = this.pullQueue.shift();
-            reject(error);
-        }
+        this.pullQueue.forEach(([resolve, reject]) => {
+            return reject(error);
+        });
+        this.pullQueue.length = 0;
         this.emptyQueue();
         return Promise.reject(error);
     }

--- a/package.json
+++ b/package.json
@@ -12,13 +12,19 @@
     "url": "https://github.com/johnvmt/event-emitter-async-iterator"
   },
   "scripts": {
-    "test": "mocha --colors ./test/*.test.js",
+    "test": "ts-mocha --colors ./tests/*.test.ts",
     "build": "tsc -p .",
     "build:watch": "tsc -p . --watch"
   },
   "devDependencies": {
-    "typescript": "^4.2.3",
-    "mocha": "^8.3.1"
+    "@types/chai": "^4.2.15",
+    "@types/chai-as-promised": "^7.1.3",
+    "chai": "^4.3.3",
+    "chai-as-promised": "^7.1.1",
+    "lodash": "^4.17.21",
+    "mocha": "^8.3.1",
+    "ts-mocha": "^8.0.0",
+    "typescript": "^4.2.3"
   },
   "dependencies": {
     "eventemitter3": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "test": "mocha --colors ./test/*.test.js",
-    "build": "tsc -p ."
+    "build": "tsc -p .",
+    "build:watch": "tsc -p . --watch"
   },
   "devDependencies": {
     "typescript": "^4.2.3",

--- a/src/EventEmitterAsyncIterator.ts
+++ b/src/EventEmitterAsyncIterator.ts
@@ -70,11 +70,10 @@ class EventEmitterAsyncIterator extends EventEmitter implements AsyncIterator<an
 	public throw(error: Error): Promise<IteratorResult<any, any>> {
 		this.listening = false;
 
-		if(this.pullQueue.length !== 0) {
-			const [ resolve, reject ] = this.pullQueue.shift()!;
-
-			reject(error);
-		}
+		this.pullQueue.forEach(([resolve, reject]) => {
+			return reject(error);
+		});
+		this.pullQueue.length = 0;
 
 		this.emptyQueue();
 		return Promise.reject(error);

--- a/src/EventEmitterAsyncIterator.ts
+++ b/src/EventEmitterAsyncIterator.ts
@@ -10,6 +10,7 @@ class EventEmitterAsyncIterator extends EventEmitter implements AsyncIterator<an
 	protected listening: boolean;
 
 	public readonly [iterall.$$asyncIterator]: () => this;
+	public readonly [Symbol.asyncIterator]: () => this;
 
 	constructor() {
 		super();
@@ -19,6 +20,9 @@ class EventEmitterAsyncIterator extends EventEmitter implements AsyncIterator<an
 		this.listening = true;
 
 		this[iterall.$$asyncIterator] = () => this;
+		if (Symbol.asyncIterator) {
+			this[Symbol.asyncIterator] = () => this;
+		}
 	}
 
 	public emptyQueue(): void {

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,0 +1,51 @@
+import { assert, expect, use } from "chai";
+import _ from "lodash";
+import EventEmitterAsyncIterator from "../src/EventEmitterAsyncIterator";
+import chaiAsPromised from "chai-as-promised";
+
+use(chaiAsPromised);
+
+describe("basic tests", function () {
+    it("some events", async function () {
+        const events = _.range(30, 40);
+
+        const e = new EventEmitterAsyncIterator();
+
+        for (const event of events) {
+            e.pushValue(event);
+        }
+
+        const emittedEvents = [];
+        for await (const event of e) {
+            emittedEvents.push(event);
+
+            if (emittedEvents.length == events.length) {
+                break;
+            }
+        }
+
+        assert.sameOrderedMembers(emittedEvents, events);
+    });
+
+    it("some events with throw", async function () {
+        const e = new EventEmitterAsyncIterator();
+
+        e.pushValue("a");
+        assert.deepEqual(await e.next(), { done: false, value: "a" });
+
+        expect(e.throw(new Error("foobar"))).to.be.rejectedWith(Error, "foobar");
+    });
+
+    it("some events with throw 2", async function () {
+        const e = new EventEmitterAsyncIterator();
+
+        e.pushValue("a");
+        assert.deepEqual(await e.next(), { done: false, value: "a" });
+
+        const promisedError = e.next();
+
+        expect(e.throw(new Error("foobar"))).to.be.rejectedWith(Error, "foobar");
+
+        expect(promisedError).to.be.rejectedWith(Error, "foobar");
+    });
+});

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -27,6 +27,21 @@ describe("basic tests", function () {
         assert.sameOrderedMembers(emittedEvents, events);
     });
 
+    it("some events 2", async function () {
+        const e = new EventEmitterAsyncIterator();
+
+        e.pushValue("a");
+        assert.deepEqual(await e.next(), { done: false, value: "a" });
+
+        e.pushValue("b");
+        assert.deepEqual(await e.next(), { done: false, value: "b" });
+
+        e.pushValue("c");
+        e.pushValue("d");
+        assert.deepEqual(await e.next(), { done: false, value: "c" });
+        assert.deepEqual(await e.next(), { done: false, value: "d" });
+    });
+
     it("some events with throw", async function () {
         const e = new EventEmitterAsyncIterator();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,12 @@
     "declaration": true,
     "outDir": "./cjs",
   },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Recommended"
 }


### PR DESCRIPTION
Hi,

I have made some more changes:
* Added some basic tests (using `ts-mocha` for typescript handling)
* If available, also use `Symbol.asyncIterator` (required for typescript, otherwise ts does not recognise the emitter as async iterator)
* On `throw()` **all** "active" promises are rejected

The last one may be a breaking change. Previous `throw` returned just a rejected promise but if a promise has been created before this (which is to be expected, it is an async iterator), those would not be rejected. With my changes, they will be rejected.

